### PR TITLE
Fail on nested

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,8 @@
   Use with caution. Specifically, make sure you aren't inadvertantly
   wrapping code that already performs sleep + retry. Otherwise, you'll
   end up with a series of nested retry's that could take much longer to
-  work than you expect. 
+  work than you expect. There is protection by default against accidentally
+  nesting calls to attempt.
 
   Also, this library uses the timeout library internally, which has some
   known issues. See Future Plans, below.

--- a/test/test_attempt.rb
+++ b/test/test_attempt.rb
@@ -55,6 +55,49 @@ class TC_Attempt < Test::Unit::TestCase
     assert_raises(RuntimeError){ attempt(tries: 2, interval: 2){ raise } }
   end
 
+  test "attempt raises exception when nested" do
+    assert_raises(Attempt::NestedError){
+      attempt(tries: 2, interval: 2){
+        attempt(tries: 2, interval: 2){
+        }
+      }
+    }
+  end
+
+  test "attempt warns when nested" do
+    assert_warn(StructuredWarnings::StandardWarning){
+      attempt(tries: 2, interval: 2, allow_nested: true){
+        attempt(tries: 2, interval: 2){
+        }
+      }
+    }
+
+    assert_warn(StructuredWarnings::StandardWarning){
+      attempt(tries: 2, interval: 2, allow_nested: true){
+        attempt(tries: 2, interval: 2, allow_nested: true){
+          attempt(tries: 2, interval: 2){
+          }
+        }
+      }
+    }
+
+    assert_warn(StructuredWarnings::StandardWarning){
+      attempt(tries: 2, interval: 2, allow_nested: true){
+        attempt(tries: 2, interval: 2, allow_nested: true){
+          attempt(tries: 2, interval: 2, allow_nested: false){
+          }
+        }
+      }
+    }
+
+    assert_raises(Attempt::NestedError){
+      attempt(tries: 2, interval: 2){
+        attempt(tries: 2, interval: 2, allow_nested: true){
+        }
+      }
+    }
+  end
+
   def teardown
     @tries    = nil
     @interval = nil


### PR DESCRIPTION
This protects against nesting calls to `attempt` - by default, an `Attempt::NestedError` will be raised.

I'm not sure about the above, as it could potentially break existing uses of this gem. So, either a major version bump or make the default just to warn but not fail. My preference would be to keep default as is, as I doubt whether people would deliberately want to nest attempts most of the time.