### PR TITLE
Updated structured_warnings dependency.

### DIFF
--- a/attempt.gemspec
+++ b/attempt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     'wiki_uri'        => 'https://github.com/djberg96/attempt/wiki'
   }
 
-  spec.add_dependency('structured_warnings', '~> 0.3.0')
+  spec.add_dependency('structured_warnings', '>= 0.3.0')
   spec.add_dependency('safe_timeout', '~> 0.0.5')
 
   spec.add_development_dependency('test-unit')


### PR DESCRIPTION
For ruby 2.7.1 version 0.3.0 fails with (StructuredWarnings::BuiltInWarning)TypeError: wrong argument type Hash (expected String)
versions 0.4.0 and 0.5.0 of "structured_warnings" work fine. 

Could you allow newer versions. Thank you