### PR TITLE
Add gemfile, update gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org' do
+  gem 'rake'
+  gem 'structured_warnings', '~> 0.4.0'
+  gem 'safe_timeout', '~> 0.0.5'
+  group 'test' do
+    gem 'test-unit', '~> 3.0'
+  end
+end

--- a/attempt.gemspec
+++ b/attempt.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     'wiki_uri'        => 'https://github.com/djberg96/attempt/wiki'
   }
 
-  spec.add_dependency('structured_warnings', '~> 0.3.0')
+  spec.add_dependency('structured_warnings', '~> 0.4.0')
   spec.add_dependency('safe_timeout', '~> 0.0.5')
 
   spec.add_development_dependency('test-unit')
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.description = <<-EOF
     The attempt library provides a thin wrapper for the typical
     begin/rescue/sleep/retry dance. Use this in order to robustly
-    handle blocks of code that could briefly flake out, such as a socket
+    handle blocks of code that could briefly flake out, such as an http
     or database connection, where it's often better to try again after
     a brief period rather than fail immediately.
   EOF


### PR DESCRIPTION
This adds a Gemfile and updates the structured_warnings dependency so that it works with Ruby 2.7.x.